### PR TITLE
feat: support format=esm in esbuild config

### DIFF
--- a/test/fixtures/with-esm-esbuild-config/esbuild.config.js
+++ b/test/fixtures/with-esm-esbuild-config/esbuild.config.js
@@ -1,0 +1,4 @@
+/** @type {import("esbuild").BuildOptions} */
+export default {
+  format: "esm",
+};

--- a/test/fixtures/with-esm-esbuild-config/with-import-meta.ts
+++ b/test/fixtures/with-esm-esbuild-config/with-import-meta.ts
@@ -1,0 +1,7 @@
+describe("suite", () => {
+  it("passes when esm is supported", () => {
+    if (typeof import.meta.url !== "string") {
+      throw new Error("import.meta.url is not a string");
+    }
+  });
+});

--- a/test/mocha-web.spec.ts
+++ b/test/mocha-web.spec.ts
@@ -153,4 +153,15 @@ describe("mocha-web", function () {
     expect(output, output).to.include("body background-color: rgb(0, 255, 0)");
     expect(status).to.equal(0);
   });
+
+  it("supports esm syntax when esbuild config specifies format=esm", () => {
+    const { output, status } = runMochaPlay({
+      args: ["./with-import-meta.ts"],
+      fixture: "with-esm-esbuild-config",
+    });
+
+    expect(output).to.include("Found 1 test files");
+    expect(output).to.include("1 passing");
+    expect(status).to.equal(0);
+  });
 });


### PR DESCRIPTION
will use type="module" for tests.js when it is specified, allowing esm-specific syntax